### PR TITLE
Fix autoupgrade with user installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,5 @@
 AutoUpgrade
 ===========
-[![PyPI](https://img.shields.io/pypi/v/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![GitHub issues](https://img.shields.io/github/issues/vuolter/autoupgrade.svg)]
-(https://github.com/vuolter/autoupgrade/issues)
-[![PyPI](https://img.shields.io/pypi/dm/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![PyPI](https://img.shields.io/pypi/l/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![PyPI](https://img.shields.io/pypi/format/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![PyPI](https://img.shields.io/pypi/pyversions/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![PyPI](https://img.shields.io/pypi/status/autoupgrade-ng.svg)]
-(https://pypi.python.org/pypi/autoupgrade-ng)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/WalterPurcaro.svg?style=social)]
-(https://twitter.com/intent/tweet?text=Wow:&url=%5Bobject%20Object%5D)
 
 Automatic upgrade of PyPI packages.
 
@@ -53,7 +37,7 @@ Old methods are still supported; you can accomplish the same task calling:
 Installation
 ------------
 
-    pip install autoupgrade-ng
+    pip install autoupgrade-prima
 
 All the modules will be installed under the _autoupgrade_ package, so **make
 sure you have already removed the old [AutoUpgrade package]

--- a/autoupgrade/package.py
+++ b/autoupgrade/package.py
@@ -4,16 +4,13 @@ import os
 import re
 import sys
 
-import pip
+from pip import _internal as pip
 import pkg_resources
 
 from .exceptions import NoVersionsError, PIPError, PkgNotFoundError
 from .utils import ver_to_tuple
 
-try:
-    from urllib.request import urlopen
-except Exception:
-    from urllib import urlopen
+import requests
 
 
 class Package(object):
@@ -131,12 +128,12 @@ class Package(object):
 
     def _get_highest_version(self):
         url = "{}/{}/".format(self.index, self.pkg)
-        html = urlopen(url)
-        if html.getcode() != 200:
+        r = requests.get(url)
+        if r.status_code != 200:
             raise PkgNotFoundError
-        pattr = r'>{}-(.+?)<'.format(self.pkg)
+        pattr = r'>{}-((?:\d+\D*)(?:\.\d+\D*)*)-'.format(self.pkg)
         versions = map(ver_to_tuple,
-                       re.findall(pattr, html.read(), flags=re.I))
+                       re.findall(pattr, r.text, flags=re.I))
         if not versions:
             raise NoVersionsError
         return max(versions)

--- a/autoupgrade/package.py
+++ b/autoupgrade/package.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import re
+import site
 import sys
 
 from pip._internal import main as pip
@@ -127,11 +128,14 @@ class Package(object):
         Return True if the package has been installed as an user package
         (pip's `--user` option) or False otherwise.
         """
-        # Currently we just check if the module location is inside the
-        # user home, which is kind of a shacky check.
-        # Better solutions are welcome
         installation_path = pkg_resources.get_distribution(self.pkg).location
-        return installation_path.startswith(str(pathlib.Path.home()))
+        try:
+            user_site_directory = site.getusersitepackages()
+            return installation_path.startswith(user_site_directory)
+        except AttributeError:
+            # Some versions of virtualenv ship with their own version of the
+            # site module without the getusersitepacakges function.
+            return False
 
     def _get_current(self):
         try:

--- a/autoupgrade/package.py
+++ b/autoupgrade/package.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-from pip import _internal as pip
+from pip._internal import main as pip
 import pkg_resources
 
 from .exceptions import NoVersionsError, PIPError, PkgNotFoundError

--- a/autoupgrade/package.py
+++ b/autoupgrade/package.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import pathlib
 import re
 import sys
 
@@ -82,6 +83,9 @@ class Package(object):
         if prerelease:
             pip_args.append("--pre")
 
+        if self._is_user_installed():
+            pip_args.append('--user')
+
         proxy = os.environ.get('http_proxy')
         if proxy:
             pip_args.extend(['--proxy', proxy])
@@ -117,6 +121,17 @@ class Package(object):
         current = self._get_current()
         highest = self._get_highest_version()
         return highest > current
+
+    def _is_user_installed(self):
+        """
+        Return True if the package has been installed as an user package
+        (pip's `--user` option) or False otherwise.
+        """
+        # Currently we just check if the module location is inside the
+        # user home, which is kind of a shacky check.
+        # Better solutions are welcome
+        installation_path = pkg_resources.get_distribution(self.pkg).location
+        return installation_path.startswith(str(pathlib.Path.home()))
 
     def _get_current(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="autoupgrade-prima",
-    version="0.3.2",
+    version="0.3.3",
     author="Walter Purcaro",
     author_email="vuolter@gmail.com",
     description="Automatic upgrade of PyPI packages",

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 from setuptools import setup
 
 setup(
-    name="autoupgrade-ng",
-    version="0.3.0",
+    name="autoupgrade-prima",
+    version="0.3.2",
     author="Walter Purcaro",
     author_email="vuolter@gmail.com",
     description="Automatic upgrade of PyPI packages",
@@ -12,9 +12,9 @@ setup(
     keywords=['autoupgrade', 'pip-upgrade', 'pip'],
     packages=['autoupgrade'],
     include_package_data=True,
-    url="https://github.com/vuolter/autoupgrade",
-    download_url="https://github.com/vuolter/autoupgrade/releases",
-    install_requires=['pip'],
+    url="https://github.com/primait/autoupgrade",
+    download_url="https://github.com/primait/autoupgrade/releases",
+    install_requires=['pip', 'requests'],
     obsoletes=['autoupgrade'],
     license='MIT License',
     zip_safe=True,


### PR DESCRIPTION
Controlla se il pacchetto è installato nella user site-packages ([PEP 370](https://www.python.org/dev/peps/pep-0370/), opzione `--user` di pip) e, in caso positivio, fa l'upgrade mantenendo `--user`.

Risolve suite-py che si rompe nell'autoupgrade se installato come `--user`